### PR TITLE
Add REST controllers for domain models

### DIFF
--- a/src/main/java/com/project/EasyRoom/controller/BlogController.java
+++ b/src/main/java/com/project/EasyRoom/controller/BlogController.java
@@ -1,0 +1,55 @@
+package com.project.EasyRoom.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.project.EasyRoom.model.Blog;
+import com.project.EasyRoom.service.BlogService;
+
+@RestController
+@RequestMapping("/api")
+public class BlogController {
+
+    @Autowired
+    private BlogService blogService;
+
+    @GetMapping("/blogs")
+    public List<Blog> getAll() {
+        return blogService.getAllBlog();
+    }
+
+    @GetMapping("/blogs/{id}")
+    public ResponseEntity<Blog> getById(@PathVariable int id) {
+        Blog blog = blogService.getBlogById(id);
+        if (blog != null) {
+            return ResponseEntity.ok(blog);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/blogs")
+    public Blog create(@RequestBody Blog blog) {
+        blogService.saveBlog(blog);
+        return blog;
+    }
+
+    @PutMapping("/blogs/{id}")
+    public ResponseEntity<Blog> update(@PathVariable int id, @RequestBody Blog blog) {
+        Blog existing = blogService.getBlogById(id);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        blog.setIdBlog(id);
+        blogService.saveBlog(blog);
+        return ResponseEntity.ok(blog);
+    }
+
+    @DeleteMapping("/blogs/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        blogService.deleteBlog(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/project/EasyRoom/controller/BookingController.java
+++ b/src/main/java/com/project/EasyRoom/controller/BookingController.java
@@ -1,0 +1,55 @@
+package com.project.EasyRoom.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.project.EasyRoom.model.Booking;
+import com.project.EasyRoom.service.BookingService;
+
+@RestController
+@RequestMapping("/api")
+public class BookingController {
+
+    @Autowired
+    private BookingService bookingService;
+
+    @GetMapping("/bookings")
+    public List<Booking> getAll() {
+        return bookingService.getAllBookings();
+    }
+
+    @GetMapping("/bookings/{id}")
+    public ResponseEntity<Booking> getById(@PathVariable int id) {
+        Booking booking = bookingService.getBookingById(id);
+        if (booking != null) {
+            return ResponseEntity.ok(booking);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/bookings")
+    public Booking create(@RequestBody Booking booking) {
+        bookingService.saveBooking(booking);
+        return booking;
+    }
+
+    @PutMapping("/bookings/{id}")
+    public ResponseEntity<Booking> update(@PathVariable int id, @RequestBody Booking booking) {
+        Booking existing = bookingService.getBookingById(id);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        booking.setIdBooking(id);
+        bookingService.saveBooking(booking);
+        return ResponseEntity.ok(booking);
+    }
+
+    @DeleteMapping("/bookings/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        bookingService.deleteBookingById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/project/EasyRoom/controller/ContractController.java
+++ b/src/main/java/com/project/EasyRoom/controller/ContractController.java
@@ -1,0 +1,55 @@
+package com.project.EasyRoom.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.project.EasyRoom.model.Contract;
+import com.project.EasyRoom.service.ContractService;
+
+@RestController
+@RequestMapping("/api")
+public class ContractController {
+
+    @Autowired
+    private ContractService contractService;
+
+    @GetMapping("/contracts")
+    public List<Contract> getAll() {
+        return contractService.getAllContract();
+    }
+
+    @GetMapping("/contracts/{id}")
+    public ResponseEntity<Contract> getById(@PathVariable int id) {
+        Contract contract = contractService.getContractById(id);
+        if (contract != null) {
+            return ResponseEntity.ok(contract);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/contracts")
+    public Contract create(@RequestBody Contract contract) {
+        contractService.saveContract(contract);
+        return contract;
+    }
+
+    @PutMapping("/contracts/{id}")
+    public ResponseEntity<Contract> update(@PathVariable int id, @RequestBody Contract contract) {
+        Contract existing = contractService.getContractById(id);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        contract.setIdContract(id);
+        contractService.saveContract(contract);
+        return ResponseEntity.ok(contract);
+    }
+
+    @DeleteMapping("/contracts/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        contractService.deleteContract(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/project/EasyRoom/controller/EventController.java
+++ b/src/main/java/com/project/EasyRoom/controller/EventController.java
@@ -1,0 +1,55 @@
+package com.project.EasyRoom.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.project.EasyRoom.model.Event;
+import com.project.EasyRoom.service.EventService;
+
+@RestController
+@RequestMapping("/api")
+public class EventController {
+
+    @Autowired
+    private EventService eventService;
+
+    @GetMapping("/events")
+    public List<Event> getAll() {
+        return eventService.getAllEvents();
+    }
+
+    @GetMapping("/events/{id}")
+    public ResponseEntity<Event> getById(@PathVariable int id) {
+        Event event = eventService.getEventById(id);
+        if (event != null) {
+            return ResponseEntity.ok(event);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/events")
+    public Event create(@RequestBody Event event) {
+        eventService.saveEvent(event);
+        return event;
+    }
+
+    @PutMapping("/events/{id}")
+    public ResponseEntity<Event> update(@PathVariable int id, @RequestBody Event event) {
+        Event existing = eventService.getEventById(id);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        event.setIdEvent(id);
+        eventService.saveEvent(event);
+        return ResponseEntity.ok(event);
+    }
+
+    @DeleteMapping("/events/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        eventService.deleteEventById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/project/EasyRoom/controller/InsuranceController.java
+++ b/src/main/java/com/project/EasyRoom/controller/InsuranceController.java
@@ -1,0 +1,55 @@
+package com.project.EasyRoom.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.project.EasyRoom.model.Insurance;
+import com.project.EasyRoom.service.InsuranceService;
+
+@RestController
+@RequestMapping("/api")
+public class InsuranceController {
+
+    @Autowired
+    private InsuranceService insuranceService;
+
+    @GetMapping("/insurances")
+    public List<Insurance> getAll() {
+        return insuranceService.getAllInsurances();
+    }
+
+    @GetMapping("/insurances/{id}")
+    public ResponseEntity<Insurance> getById(@PathVariable int id) {
+        Insurance insurance = insuranceService.getInsuranceById(id);
+        if (insurance != null) {
+            return ResponseEntity.ok(insurance);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/insurances")
+    public Insurance create(@RequestBody Insurance insurance) {
+        insuranceService.saveInsurance(insurance);
+        return insurance;
+    }
+
+    @PutMapping("/insurances/{id}")
+    public ResponseEntity<Insurance> update(@PathVariable int id, @RequestBody Insurance insurance) {
+        Insurance existing = insuranceService.getInsuranceById(id);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        insurance.setIdInsurance(id);
+        insuranceService.saveInsurance(insurance);
+        return ResponseEntity.ok(insurance);
+    }
+
+    @DeleteMapping("/insurances/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        insuranceService.deleteInsuranceById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/project/EasyRoom/controller/PaymentBillController.java
+++ b/src/main/java/com/project/EasyRoom/controller/PaymentBillController.java
@@ -1,0 +1,55 @@
+package com.project.EasyRoom.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.project.EasyRoom.model.PaymentBill;
+import com.project.EasyRoom.service.PaymentBillService;
+
+@RestController
+@RequestMapping("/api")
+public class PaymentBillController {
+
+    @Autowired
+    private PaymentBillService paymentBillService;
+
+    @GetMapping("/payment-bills")
+    public List<PaymentBill> getAll() {
+        return paymentBillService.getAllPaymentBills();
+    }
+
+    @GetMapping("/payment-bills/{id}")
+    public ResponseEntity<PaymentBill> getById(@PathVariable int id) {
+        PaymentBill bill = paymentBillService.getPaymentBillById(id);
+        if (bill != null) {
+            return ResponseEntity.ok(bill);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/payment-bills")
+    public PaymentBill create(@RequestBody PaymentBill bill) {
+        paymentBillService.savePaymentBill(bill);
+        return bill;
+    }
+
+    @PutMapping("/payment-bills/{id}")
+    public ResponseEntity<PaymentBill> update(@PathVariable int id, @RequestBody PaymentBill bill) {
+        PaymentBill existing = paymentBillService.getPaymentBillById(id);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        bill.setIdPaymentBill(id);
+        paymentBillService.savePaymentBill(bill);
+        return ResponseEntity.ok(bill);
+    }
+
+    @DeleteMapping("/payment-bills/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        paymentBillService.deletePaymentBillById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/project/EasyRoom/controller/PolicyAndTermsController.java
+++ b/src/main/java/com/project/EasyRoom/controller/PolicyAndTermsController.java
@@ -1,0 +1,55 @@
+package com.project.EasyRoom.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.project.EasyRoom.model.PolicyAndTerms;
+import com.project.EasyRoom.service.PolicyAndTermsService;
+
+@RestController
+@RequestMapping("/api")
+public class PolicyAndTermsController {
+
+    @Autowired
+    private PolicyAndTermsService policyAndTermsService;
+
+    @GetMapping("/policy-terms")
+    public List<PolicyAndTerms> getAll() {
+        return policyAndTermsService.getAllPolicyAndTermss();
+    }
+
+    @GetMapping("/policy-terms/{id}")
+    public ResponseEntity<PolicyAndTerms> getById(@PathVariable int id) {
+        PolicyAndTerms policy = policyAndTermsService.getPolicyAndTermsById(id);
+        if (policy != null) {
+            return ResponseEntity.ok(policy);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/policy-terms")
+    public PolicyAndTerms create(@RequestBody PolicyAndTerms policy) {
+        policyAndTermsService.savePolicyAndTerms(policy);
+        return policy;
+    }
+
+    @PutMapping("/policy-terms/{id}")
+    public ResponseEntity<PolicyAndTerms> update(@PathVariable int id, @RequestBody PolicyAndTerms policy) {
+        PolicyAndTerms existing = policyAndTermsService.getPolicyAndTermsById(id);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        policy.setIdPolicy(id);
+        policyAndTermsService.savePolicyAndTerms(policy);
+        return ResponseEntity.ok(policy);
+    }
+
+    @DeleteMapping("/policy-terms/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        policyAndTermsService.deletePolicyAndTermsById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/project/EasyRoom/controller/RequestWithdrawalController.java
+++ b/src/main/java/com/project/EasyRoom/controller/RequestWithdrawalController.java
@@ -1,0 +1,55 @@
+package com.project.EasyRoom.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.project.EasyRoom.model.RequestWithdrawal;
+import com.project.EasyRoom.service.RequestWithdrawalService;
+
+@RestController
+@RequestMapping("/api")
+public class RequestWithdrawalController {
+
+    @Autowired
+    private RequestWithdrawalService requestWithdrawalService;
+
+    @GetMapping("/request-withdrawals")
+    public List<RequestWithdrawal> getAll() {
+        return requestWithdrawalService.getAllRequestWithdrawals();
+    }
+
+    @GetMapping("/request-withdrawals/{id}")
+    public ResponseEntity<RequestWithdrawal> getById(@PathVariable int id) {
+        RequestWithdrawal req = requestWithdrawalService.getRequestWithdrawalById(id);
+        if (req != null) {
+            return ResponseEntity.ok(req);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/request-withdrawals")
+    public RequestWithdrawal create(@RequestBody RequestWithdrawal req) {
+        requestWithdrawalService.saveRequestWithdrawal(req);
+        return req;
+    }
+
+    @PutMapping("/request-withdrawals/{id}")
+    public ResponseEntity<RequestWithdrawal> update(@PathVariable int id, @RequestBody RequestWithdrawal req) {
+        RequestWithdrawal existing = requestWithdrawalService.getRequestWithdrawalById(id);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        req.setIdRequest(id);
+        requestWithdrawalService.saveRequestWithdrawal(req);
+        return ResponseEntity.ok(req);
+    }
+
+    @DeleteMapping("/request-withdrawals/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        requestWithdrawalService.deleteRequestWithdrawalById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/project/EasyRoom/controller/RoomController.java
+++ b/src/main/java/com/project/EasyRoom/controller/RoomController.java
@@ -1,0 +1,55 @@
+package com.project.EasyRoom.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.project.EasyRoom.model.Room;
+import com.project.EasyRoom.service.RoomService;
+
+@RestController
+@RequestMapping("/api")
+public class RoomController {
+
+    @Autowired
+    private RoomService roomService;
+
+    @GetMapping("/rooms")
+    public List<Room> getAll() {
+        return roomService.getAllRoomsOrderByTitle();
+    }
+
+    @GetMapping("/rooms/{id}")
+    public ResponseEntity<Room> getById(@PathVariable int id) {
+        Room room = roomService.getRoomById(id);
+        if (room != null) {
+            return ResponseEntity.ok(room);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/rooms")
+    public Room create(@RequestBody Room room) {
+        roomService.saveRoom(room);
+        return room;
+    }
+
+    @PutMapping("/rooms/{id}")
+    public ResponseEntity<Room> update(@PathVariable int id, @RequestBody Room room) {
+        Room existing = roomService.getRoomById(id);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        room.setIdRoom(id);
+        roomService.saveRoom(room);
+        return ResponseEntity.ok(room);
+    }
+
+    @DeleteMapping("/rooms/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        roomService.deleteRoomById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/project/EasyRoom/controller/RoomTypeController.java
+++ b/src/main/java/com/project/EasyRoom/controller/RoomTypeController.java
@@ -1,0 +1,55 @@
+package com.project.EasyRoom.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.project.EasyRoom.model.RoomType;
+import com.project.EasyRoom.service.RoomTypeService;
+
+@RestController
+@RequestMapping("/api")
+public class RoomTypeController {
+
+    @Autowired
+    private RoomTypeService roomTypeService;
+
+    @GetMapping("/room-types")
+    public List<RoomType> getAll() {
+        return roomTypeService.getAllRoomTypes();
+    }
+
+    @GetMapping("/room-types/{id}")
+    public ResponseEntity<RoomType> getById(@PathVariable int id) {
+        RoomType roomType = roomTypeService.getRoomTypeById(id);
+        if (roomType != null) {
+            return ResponseEntity.ok(roomType);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/room-types")
+    public RoomType create(@RequestBody RoomType roomType) {
+        roomTypeService.saveRoomType(roomType);
+        return roomType;
+    }
+
+    @PutMapping("/room-types/{id}")
+    public ResponseEntity<RoomType> update(@PathVariable int id, @RequestBody RoomType roomType) {
+        RoomType existing = roomTypeService.getRoomTypeById(id);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        roomType.setIdRoomType(id);
+        roomTypeService.saveRoomType(roomType);
+        return ResponseEntity.ok(roomType);
+    }
+
+    @DeleteMapping("/room-types/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        roomTypeService.deleteRoomType(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/project/EasyRoom/controller/UserController.java
+++ b/src/main/java/com/project/EasyRoom/controller/UserController.java
@@ -1,28 +1,55 @@
 package com.project.EasyRoom.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import java.util.List;
 
-import com.project.EasyRoom.model.District;
-import com.project.EasyRoom.model.Province;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
 import com.project.EasyRoom.model.User;
-import com.project.EasyRoom.model.Ward;
-import com.project.EasyRoom.service.EncryptionPassword;
-import com.project.EasyRoom.service.UploadFile;
 import com.project.EasyRoom.service.UserService;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
-
-@Controller
+@RestController
+@RequestMapping("/api")
 public class UserController {
-	
-}
 
+    @Autowired
+    private UserService userService;
+
+    @GetMapping("/users")
+    public List<User> getAll() {
+        return userService.getAllUsers();
+    }
+
+    @GetMapping("/users/{id}")
+    public ResponseEntity<User> getById(@PathVariable int id) {
+        User user = userService.getUserById(id);
+        if (user != null) {
+            return ResponseEntity.ok(user);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @PostMapping("/users")
+    public User create(@RequestBody User user) {
+        userService.saveUser(user);
+        return user;
+    }
+
+    @PutMapping("/users/{id}")
+    public ResponseEntity<User> update(@PathVariable int id, @RequestBody User user) {
+        User existing = userService.getUserById(id);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        user.setIdUser(id);
+        userService.saveUser(user);
+        return ResponseEntity.ok(user);
+    }
+
+    @DeleteMapping("/users/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/project/EasyRoom/service/BookingService.java
+++ b/src/main/java/com/project/EasyRoom/service/BookingService.java
@@ -30,4 +30,6 @@ public interface BookingService {
     String[] getRevenueByDate(String dateStart, String dateEnd, int statusBill);
 
     String[] getRevenueByDateAndUser(String dateStart, String dateEnd, int statusBill, int idUser);
+
+    List<Booking> getAllBookings();
 }

--- a/src/main/java/com/project/EasyRoom/service/BookingServiceImpl.java
+++ b/src/main/java/com/project/EasyRoom/service/BookingServiceImpl.java
@@ -102,4 +102,9 @@ public class BookingServiceImpl implements BookingService {
     public String[] getRevenueByDateAndUser(String dateStart, String dateEnd, int statusBill, int idUser) {
         return bookingRepository.sumRevenueOnTimeByIdUser(dateStart, dateEnd, statusBill, idUser);
     }
+
+    @Override
+    public List<Booking> getAllBookings() {
+        return bookingRepository.findAll();
+    }
 }


### PR DESCRIPTION
## Summary
- implement REST controllers for Blog, Booking, Contract, Event, Insurance, PaymentBill, PolicyAndTerms, RequestWithdrawal, Room, RoomType, and User
- extend `BookingService` with `getAllBookings()`
- provide CRUD endpoints under `/api`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68502415751483259076867fe6c12fa2