### PR TITLE
Implement date filtered status query

### DIFF
--- a/src/main/java/com/project/EasyRoom/repository/BookingRepository.java
+++ b/src/main/java/com/project/EasyRoom/repository/BookingRepository.java
@@ -56,6 +56,16 @@ public interface BookingRepository extends JpaRepository<Booking, Integer> {
     List<Booking> getAllBookingOnTime(@Param("dateStart") String dateStart,
                                       @Param("dateEnd") String dateEnd);
 
+    @Query(value = """
+        SELECT * FROM booking
+        WHERE status_bill = :statusBill
+          AND CONVERT(nvarchar(10), date_start, 127) >= :dateStart
+          AND CONVERT(nvarchar(10), date_end, 127) <= :dateEnd
+        """, nativeQuery = true)
+    List<Booking> getBookingOnTimeWithStatus(@Param("statusBill") int statusBill,
+                                             @Param("dateStart") String dateStart,
+                                             @Param("dateEnd") String dateEnd);
+
     // 6. Truy vấn booking + phòng + chủ trọ
     String sql = """
         SELECT b.*, r.title, r.addressRoom, r.price, u.username, u.nameDisplay, u.phone 

--- a/src/main/java/com/project/EasyRoom/service/BookingServiceImpl.java
+++ b/src/main/java/com/project/EasyRoom/service/BookingServiceImpl.java
@@ -90,7 +90,7 @@ public class BookingServiceImpl implements BookingService {
 
     @Override
     public List<Booking> getBookingOnTimeWithStatus(int statusBill, String dateStart, String dateEnd) {
-        return bookingRepository.getAllBookingByStatusBill(statusBill);
+        return bookingRepository.getBookingOnTimeWithStatus(statusBill, dateStart, dateEnd);
     }
 
     @Override

--- a/src/test/java/com/project/EasyRoom/service/BookingServiceImplTest.java
+++ b/src/test/java/com/project/EasyRoom/service/BookingServiceImplTest.java
@@ -1,0 +1,39 @@
+package com.project.EasyRoom.service;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.project.EasyRoom.model.Booking;
+import com.project.EasyRoom.repository.BookingRepository;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookingServiceImplTest {
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    @InjectMocks
+    private BookingServiceImpl bookingService;
+
+    @Test
+    void testGetBookingOnTimeWithStatusCallsRepository() {
+        List<Booking> expected = Collections.emptyList();
+        when(bookingRepository.getBookingOnTimeWithStatus(1, "2024-01-01", "2024-01-10"))
+            .thenReturn(expected);
+
+        List<Booking> result = bookingService.getBookingOnTimeWithStatus(1, "2024-01-01", "2024-01-10");
+
+        assertSame(expected, result);
+        verify(bookingRepository).getBookingOnTimeWithStatus(1, "2024-01-01", "2024-01-10");
+    }
+}


### PR DESCRIPTION
## Summary
- add repository query to search bookings by status and date
- use the new query in the booking service implementation
- add unit test verifying that service delegates to the repository

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: network access required to download Maven)*

------
https://chatgpt.com/codex/tasks/task_b_685025cf1da88325afa991411781bf76